### PR TITLE
Fixed Filter=PASS bug

### DIFF
--- a/vcf2fhir/json_generator.py
+++ b/vcf2fhir/json_generator.py
@@ -11,7 +11,7 @@ def _valid_record(record):
     if(record.is_sv == True):
         invalid_record_logger.debug("Reason: VCF INFO.SVTYPE is present. (Structural variants are excluded), Record: %s, considered sample: %s", record, record.samples[0].data)
         return False
-    if(record.FILTER is not None and record.FILTER != 'PASS'):
+    if(record.FILTER is not None and len(record.FILTER) != 0):
         invalid_record_logger.debug("Reason: VCF FILTER does not equal 'PASS' or '.', Record: %s, considered sample: %s", record, record.samples[0].data)
         return False
     if(len(record.samples) == 0 or record.samples[0].gt_type is None):

--- a/vcf2fhir/test/vcf_example1.vcf
+++ b/vcf2fhir/test/vcf_example1.vcf
@@ -11,6 +11,6 @@
 1	28	.	A	<CGA_CNVWIN>	.	.	.	GT:PS	0/1:.
 chr1	301	.	A	G	.	.	.	GT:PS	0/1:.
 1	400	.	A	G	.	.	.	GT:PS	1/1:.
-1	500	.	A	G	.	.	.	GT:PS	0|1:500
+1	500	.	A	G	.	PASS	.	GT:PS	0|1:500
 1	600	.	A	G	.	.	.	GT:PS	1|0:500
 1	700	.	A	G	.	.	.	GT:PS	0|1:700


### PR DESCRIPTION
PyVcf interprets Filter=PASS and converts it into empty array.
Changed the check of excluding record to check for length = 0
instead of FILTER==PASS.