### PR TITLE
mitochondrial DNA homoplasmic vs. heteroplasmic assignment #16

### DIFF
--- a/vcf2fhir/common.py
+++ b/vcf2fhir/common.py
@@ -41,7 +41,7 @@ class _Utilities(object):
                 prev_record = record
         return RelationTable
 
-    def getAllelicState(record):
+    def getAllelicState(record, ratio_ad_dp):
         allelicState = ''
         allelicCode = ''
         # Using  the first sample
@@ -66,7 +66,7 @@ class _Utilities(object):
                         ratio = float(sample.data.AD[0])/float(sample.data.DP)
                     else:
                         ratio = float(sample.data.AD)/float(sample.data.DP)
-                    if ratio > 0.99:
+                    if ratio > ratio_ad_dp:
                         allelicState = "homoplasmic"
                         allelicCode = "LA6704-6"
                     else:

--- a/vcf2fhir/converter.py
+++ b/vcf2fhir/converter.py
@@ -70,6 +70,9 @@ class Converter(object):
     (or 0-start, half-open) whereas VCF files and FHIR output are 1-based (or 1-start,
     fully-closed).
 
+    **ratio_ad_dp** (optional)(default value = 0.99): This ratio determine whether to assign Homoplasmic or Heteroplasmic
+     If allelic depth (FORMAT.AD) / read depth (FORMAT.DP) is greater than ratio_ad_dp then allelic state is
+      homoplasmic; else heteroplasmic.
     Returns
     -------
 
@@ -78,7 +81,8 @@ class Converter(object):
 
     """
 
-    def __init__(self, vcf_filename=None, ref_build=None, patient_id=None, has_tabix=False, conv_region_filename=None, conv_region_dict=None, region_studied_filename=None, nocall_filename=None):
+    def __init__(self, vcf_filename=None, ref_build=None, patient_id=None, has_tabix=False, conv_region_filename=None,
+                 conv_region_dict=None, region_studied_filename=None, nocall_filename=None, ratio_ad_dp=0.99):
 
         super(Converter, self).__init__()
         if not (vcf_filename):
@@ -139,6 +143,12 @@ class Converter(object):
                     "Please provide valid 'region_studied_filename'")
         else:
             self.region_studied = None
+        if not (ratio_ad_dp):
+            raise Exception('ratio_ad_dp cannot be None ')
+        if ratio_ad_dp < 0 or ratio_ad_dp >= 1:
+            raise Exception("Please provide a valid 'ratio_ad_dp' (limit 0 to 1)  ")
+
+        self.ratio_ad_dp = ratio_ad_dp
         self.has_tabix = has_tabix
         self.patient_id = patient_id
         self.ref_build = ref_build
@@ -157,7 +167,8 @@ class Converter(object):
         """
         general_logger.info("Starting VCF to FHIR Conversion")
         _get_fhir_json(self._vcf_reader, self.ref_build, self.patient_id, self.has_tabix,
-                       self.conversion_region, self.region_studied, self.nocall_region, output_filename)
+                       self.conversion_region, self.region_studied, self.nocall_region, self.ratio_ad_dp,
+                       output_filename)
         general_logger.info("Completed VCF to FHIR Conversion")
 
     def _fix_conv_region_zero_based(self, conv_region_dict):

--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -99,13 +99,13 @@ class _Fhir_Helper:
         # Observation structure : described-variants
         self.report.contained.append(contained_rs)
 
-    def add_variant_obv(self, record, ref_seq):
+    def add_variant_obv(self, record, ref_seq, ratio_ad_dp):
         # collect all the record with similar position values,
         # to utilized later in phased sequence relationship
         self._addPhaseRecords(record)
         patient_reference = reference.FHIRReference(
             {"reference": "Patient/"+self.patientID})
-        alleles = _Utilities.getAllelicState(record)
+        alleles = _Utilities.getAllelicState(record, ratio_ad_dp)
         dvuid = "dv-" + uuid4().hex[:13]
         self.fhir_report.update({str(record.POS): dvuid})
         self.result_ids.append(dvuid)

--- a/vcf2fhir/json_generator.py
+++ b/vcf2fhir/json_generator.py
@@ -47,9 +47,9 @@ def _fix_regions_chrom(region):
             _Utilities.extract_chrom_identifier)
 
 
-def _add_record_variants(record, ref_seq, patientID, fhir_helper):
+def _add_record_variants(record, ref_seq, patientID, fhir_helper, ratio_ad_dp):
     if(_valid_record(record) == True):
-        fhir_helper.add_variant_obv(record, ref_seq)
+        fhir_helper.add_variant_obv(record, ref_seq, ratio_ad_dp)
 
 
 def _add_region_studied(region_studied, nocall_region, fhir_helper, chrom, ref_seq, patientID):
@@ -61,7 +61,7 @@ def _add_region_studied(region_studied, nocall_region, fhir_helper, chrom, ref_s
             ref_seq, region_studied[chrom], nocall_region[chrom])
 
 
-def _get_fhir_json(vcf_reader, ref_build, patientID, has_tabix, conversion_region, region_studied, nocall_region, output_filename):
+def _get_fhir_json(vcf_reader, ref_build, patientID, has_tabix, conversion_region, region_studied, nocall_region,ratio_ad_dp, output_filename):
     fhir_helper = _Fhir_Helper(patientID)
     fhir_helper.initalizeReport()
     general_logger.debug("Finished Initializing empty report")
@@ -99,7 +99,7 @@ def _get_fhir_json(vcf_reader, ref_build, patientID, has_tabix, conversion_regio
                             record.CHROM = _Utilities.extract_chrom_identifier(
                                 record.CHROM)
                             _add_record_variants(
-                                record, ref_seq, patientID, fhir_helper)
+                                record, ref_seq, patientID, fhir_helper, ratio_ad_dp)
             elif not conversion_region:
                 vcf_iterator = None
                 try:
@@ -111,7 +111,7 @@ def _get_fhir_json(vcf_reader, ref_build, patientID, has_tabix, conversion_regio
                         record.CHROM = _Utilities.extract_chrom_identifier(
                             record.CHROM)
                         _add_record_variants(
-                            record, ref_seq, patientID, fhir_helper)
+                            record, ref_seq, patientID, fhir_helper, ratio_ad_dp)
     else:
         chrom_index = 1
         prev_add_chrom = ""
@@ -131,7 +131,7 @@ def _get_fhir_json(vcf_reader, ref_build, patientID, has_tabix, conversion_regio
                 ref_seq = _get_ref_seq_by_chrom(ref_build, record.CHROM)
                 if not conversion_region or conversion_region[record.CHROM, record.POS - 1: record.POS].empty == False:
                     _add_record_variants(
-                        record, ref_seq, patientID, fhir_helper)
+                        record, ref_seq, patientID, fhir_helper, ratio_ad_dp)
 
     general_logger.info("Adding all the phased sequence relationship found")
     fhir_helper.add_phased_relationship_obv()


### PR DESCRIPTION
Current software is hard-coded to assign homoplasmic vs. heteroplasmic based on: If allelic depth (FORMAT.AD) / read depth (FORMAT.DP) is greater than 99% then allelic state is homoplasmic; else heteroplasmic.

Change the '99%' to a configurable parameter.