### PR TITLE
Data Type Validation for 'has_tabix' and 'ratio_ad_dp'

### DIFF
--- a/vcf2fhir/common.py
+++ b/vcf2fhir/common.py
@@ -95,6 +95,20 @@ class _Utilities(object):
         result = re.match(pattern, chrom)
         return bool(result)
 
+    def validate_ratio_ad_dp(ratio_ad_dp):
+        if not (ratio_ad_dp):
+            return False
+        if not isinstance(ratio_ad_dp, float):
+            return False
+        if ratio_ad_dp < 0 or ratio_ad_dp >= 1:
+            return False
+        return True
+
+    def validate_has_tabix(has_tabix):
+        if not isinstance(has_tabix, bool):
+            return False
+        return True
+
     def _error_log_allelicstate(record):
         general_logger.error(
             "Cannot Determine AllelicState for: %s , considered sample: %s", record, record.samples[0].data)

--- a/vcf2fhir/converter.py
+++ b/vcf2fhir/converter.py
@@ -3,6 +3,7 @@ import pyranges
 from .json_generator import _get_fhir_json
 import logging
 import sys
+from .common import _Utilities
 general_logger = logging.getLogger('vcf2fhir.general')
 """Converter for a VCF version >4.1 file."""
 
@@ -143,10 +144,12 @@ class Converter(object):
                     "Please provide valid 'region_studied_filename'")
         else:
             self.region_studied = None
-        if not (ratio_ad_dp):
-            raise Exception('ratio_ad_dp cannot be None ')
-        if ratio_ad_dp < 0 or ratio_ad_dp >= 1:
-            raise Exception("Please provide a valid 'ratio_ad_dp' (limit 0 to 1)  ")
+        
+        if not _Utilities.validate_has_tabix(has_tabix):
+            raise Exception("Please provide a valid 'has_tabix'")
+
+        if not _Utilities.validate_ratio_ad_dp(ratio_ad_dp):
+            raise Exception("Please provide a valid 'ratio_ad_dp'")
 
         self.ratio_ad_dp = ratio_ad_dp
         self.has_tabix = has_tabix

--- a/vcf2fhir/test/test_vcf2fhir.py
+++ b/vcf2fhir/test/test_vcf2fhir.py
@@ -422,12 +422,34 @@ class TestChromIdentifier(unittest.TestCase):
                 chrom), recognized[i])
             i += 1
 
+class TestDataType(unittest.TestCase):
+
+    def test_validate_ratio_ad_dp(self):
+        ratio_ad_dp = [0.2, 0.65, 0.99, 1.3, -0.7, "Chr", False, True]
+        valid = [True, True, True, False, False, False, False, False]
+        i = 0
+        for value in ratio_ad_dp:
+            self.assertEqual(_Utilities.validate_ratio_ad_dp(
+                value), valid[i])
+            i += 1
+
+    def test_validate_has_tabix(self):
+        has_tabix = [True, False, 1, 23.4, 'C', "CHROM"]
+        valid = [True, True, False, False, False, False]
+        i = 0
+        for value in has_tabix:
+            self.assertEqual(_Utilities.validate_has_tabix(
+                value), valid[i])
+            i += 1
+
 
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVcf2FhirInputs))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestTranslation))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestLogger))
 suite.addTests(unittest.TestLoader(
 ).loadTestsFromTestCase(TestChromIdentifier))
+suite.addTests(unittest.TestLoader(
+).loadTestsFromTestCase(TestDataType))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds data type validation for 'has_tabix' and 'ratio_ad_dp' to ensure that they are of the correct data type.
Fixes #30 