### PR TITLE
Refactored GitHub Actions to add PEP 8 formatting validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Python Style Checker
+        uses: andymckay/pycodestyle-action@0.1.3
       - name: Install pip
         run: python -m pip install --upgrade pip
       - name: Install cython wheel


### PR DESCRIPTION
## Description

Refactored GitHub Actions to add a step to validate PEP 8 formatting before running the unit tests.

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
