### PR TITLE
Issue #36: Remove 'Human reference sequence assembly version' compone…

### DIFF
--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -256,32 +256,6 @@ class _Fhir_Helper:
         )
         observation_dv.component = []
 
-        observation_dv_component1 = observation.ObservationComponent()
-        observation_dv_component1.code = concept.CodeableConcept(
-            {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "62374-4",
-                        "display": "Human reference sequence assembly version"
-                    }
-                ]
-            }
-        )
-        observation_dv_component1\
-            .valueCodeableConcept = concept.CodeableConcept(
-                {
-                    "coding": [
-                        {
-                            "system": "http://loinc.org",
-                            "code": "LA14029-5",
-                            "display": "GRCh37"
-                        }
-                    ]
-                }
-            )
-        observation_dv.component.append(observation_dv_component1)
-
         observation_dv_component2 = observation.ObservationComponent()
         observation_dv_component2.code = concept.CodeableConcept(
             {

--- a/vcf2fhir/test/expected_example1_with_patient.json
+++ b/vcf2fhir/test/expected_example1_with_patient.json
@@ -53,26 +53,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -210,26 +190,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -377,26 +337,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -534,26 +474,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -701,26 +621,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -858,26 +758,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -1025,26 +905,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -1182,26 +1042,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [

--- a/vcf2fhir/test/expected_example1_wo_patient.json
+++ b/vcf2fhir/test/expected_example1_wo_patient.json
@@ -53,26 +53,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -210,26 +190,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -377,26 +337,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -534,26 +474,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -701,26 +621,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -858,26 +758,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -1025,26 +905,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -1182,26 +1042,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [

--- a/vcf2fhir/test/expected_example3.json
+++ b/vcf2fhir/test/expected_example3.json
@@ -183,26 +183,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -340,26 +320,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -507,26 +467,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -664,26 +604,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -918,26 +838,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [

--- a/vcf2fhir/test/expected_example4.json
+++ b/vcf2fhir/test/expected_example4.json
@@ -2188,26 +2188,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -2345,26 +2325,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -2512,26 +2472,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -2669,26 +2609,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [
@@ -2836,26 +2756,6 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
                                 "code": "48013-7",
                                 "display": "Genomic reference sequence ID"
                             }
@@ -2993,26 +2893,6 @@
                 ]
             },
             "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "62374-4",
-                                "display": "Human reference sequence assembly version"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA14029-5",
-                                "display": "GRCh37"
-                            }
-                        ]
-                    }
-                },
                 {
                     "code": {
                         "coding": [


### PR DESCRIPTION
fixes #36 via #53

## Description
Removed the code that created the component LOINC 62374-4 and removed this component from expected output files also.

## How Has This Been Tested?
The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

* [x]  Unit Tests
* [x]  PEP 8 Formatting Validation