### PR TITLE
Replaced np.float with float in 'fhir_helper.py'

### DIFF
--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -9,7 +9,6 @@ import fhirclient.models.fhirreference as reference
 import fhirclient.models.fhirdate as date
 import fhirclient.models.range as valRange
 import fhirclient.models.medicationstatement as medication
-import numpy as np
 from collections import OrderedDict
 from uuid import uuid4
 from .common import *
@@ -42,9 +41,9 @@ class _Fhir_Helper:
                     ]
                 }
             )
-            obv_comp.valueRange = valRange.Range({"low": {"value": np.float(
+            obv_comp.valueRange = valRange.Range({"low": {"value": float(
                 row['Start']) + 1},
-                "high": {"value": np.float(row['End']) + 1}})
+                "high": {"value": float(row['End']) + 1}})
             observation_rs_components.append(obv_comp)
         for _, row in nocall_regions.df.iterrows():
             obv_comp = observation.ObservationComponent()
@@ -59,9 +58,9 @@ class _Fhir_Helper:
                     ]
                 }
             )
-            obv_comp.valueRange = valRange.Range({"low": {"value": np.float(
+            obv_comp.valueRange = valRange.Range({"low": {"value": float(
                 row['Start']) + 1},
-                "high": {"value": np.float(row['End']) + 1}})
+                "high": {"value": float(row['End']) + 1}})
             observation_rs_components.append(obv_comp)
         return observation_rs_components
 


### PR DESCRIPTION
## Description

Replaced `np.float` with `float` in 'fhir_helper.py' because it got deprecated in NumPy 1.20 and was causing this warning
![Screenshot 2021-04-09 at 12 19 05 AM](https://user-images.githubusercontent.com/47586886/114134570-99e9ad00-9925-11eb-98ba-e2b87dacee36.jpg)

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
