### PR TITLE
Added a decorator to ignore 'Resource Warnings'

### DIFF
--- a/vcf2fhir/common.py
+++ b/vcf2fhir/common.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytz
 import logging
 import re
+import warnings
 
 
 general_logger = logging.getLogger("vcf2fhir.general")
@@ -132,6 +133,14 @@ def validate_has_tabix(has_tabix):
     if not isinstance(has_tabix, bool):
         return False
     return True
+
+
+def ignore_warnings(test_func):
+    def do_test(self, *args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            test_func(self, *args, **kwargs)
+    return do_test
 
 
 def _error_log_allelicstate(record):

--- a/vcf2fhir/test/test_integration.py
+++ b/vcf2fhir/test/test_integration.py
@@ -6,6 +6,7 @@ import json
 from os.path import join, dirname
 import shutil
 import logging
+from vcf2fhir.common import ignore_warnings
 
 suite = doctest.DocTestSuite(vcf2fhir)
 
@@ -41,16 +42,19 @@ def _validate_phase_rel(fhir_json, map_variant_index):
 
 class TestVcf2FhirInputs(unittest.TestCase):
 
+    @ignore_warnings
     def test_required_vcf_filename(self):
         with self.assertRaises(Exception) as context:
             vcf2fhir.Converter()
         self.assertTrue(
             'You must provide vcf_filename' in str(context.exception))
 
+    @ignore_warnings
     def test_invalid_vcf_filename(self):
         self.assertRaises(FileNotFoundError,
                           vcf2fhir.Converter, *['Hello', 'GRCh38'])
 
+    @ignore_warnings
     def test_required_ref_build(self):
         with self.assertRaises(Exception) as context:
             vcf2fhir.Converter(os.path.join(
@@ -59,6 +63,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
             'You must provide build number ("GRCh37" or "GRCh38")', str(
                 context.exception))
 
+    @ignore_warnings
     def test_invalid_ref_build(self):
         with self.assertRaises(Exception) as context:
             vcf2fhir.Converter(os.path.join(
@@ -67,16 +72,19 @@ class TestVcf2FhirInputs(unittest.TestCase):
             'You must provide build number ("GRCh37" or "GRCh38")', str(
                 context.exception))
 
+    @ignore_warnings
     def test_valid_ref_build_37(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
             os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_valid_ref_build_38(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
             os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh38')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_conv_region_only(self):
         conv_region_filename = os.path.join(os.path.dirname(
             __file__), 'RegionsToConvert_example3.bed')
@@ -89,6 +97,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
             conv_region_filename=conv_region_filename)
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_conv_region_dict(self):
         conv_region_dict = {
             "Chromosome": ["X", "X", "M"],
@@ -104,6 +113,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
             conv_region_dict=conv_region_dict)
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_conv_region_region_studied(self):
         region_studied_filename = os.path.join(
             os.path.dirname(__file__), 'RegionsStudied_example3.bed')
@@ -119,6 +129,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
             region_studied_filename=region_studied_filename)
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_conv_region_nocall(self):
         conv_region_filename = os.path.join(os.path.dirname(
             __file__), 'RegionsToConvert_example3.bed')
@@ -138,6 +149,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
              'when nocall_filename is provided'), str(
                 context.exception))
 
+    @ignore_warnings
     def test_no_conv_region_region_studied(self):
         region_studied_filename = os.path.join(
             os.path.dirname(__file__), 'RegionsStudied_example3.bed')
@@ -150,6 +162,7 @@ class TestVcf2FhirInputs(unittest.TestCase):
             region_studied_filename=region_studied_filename)
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
+    @ignore_warnings
     def test_no_conv_region_nocall(self):
         nocall_filename = os.path.join(os.path.dirname(
             __file__), 'NoncallableRegions_example3.bed')
@@ -180,6 +193,7 @@ class TestTranslation(unittest.TestCase):
     def tearDownClass(self):
         shutil.rmtree(self.TEST_RESULT_DIR)
 
+    @ignore_warnings
     def test_wo_patient_id(self):
         self.maxDiff = None
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
@@ -205,6 +219,7 @@ class TestTranslation(unittest.TestCase):
             expected_fhir_json = json.load(expected_output_file)
             self.assertEqual(actual_fhir_json, expected_fhir_json)
 
+    @ignore_warnings
     def test_with_patient_id(self):
         self.maxDiff = None
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(os.path.dirname(
@@ -232,12 +247,14 @@ class TestTranslation(unittest.TestCase):
 
     # FIXME: just a temporary test, later change it to a test that test
     # particular variant
+    @ignore_warnings
     def test_anotherfile(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(os.path.dirname(
             __file__), 'vcf_example2.vcf'), 'GRCh37', 'HG00628')
         o_vcf_2_fhir.convert(output_filename=os.path.join(
             os.path.dirname(__file__), self.TEST_RESULT_DIR, 'fhir2.json'))
 
+    @ignore_warnings
     def test_region_studied(self):
         self.maxDiff = None
         region_studied_filename = os.path.join(
@@ -276,6 +293,7 @@ class TestTranslation(unittest.TestCase):
             expected_fhir_json = json.load(expected_output_file)
             self.assertEqual(actual_fhir_json, expected_fhir_json)
 
+    @ignore_warnings
     def test_region_studied_dict(self):
         conv_region_dict = {
             "Chromosome": ["X", "X", "M"],
@@ -319,6 +337,7 @@ class TestTranslation(unittest.TestCase):
 
     # Check if region studied observation outside the vcf files are also
     # included in fhir report.
+    @ignore_warnings
     def test_multiple_region_studied(self):
         self.maxDiff = None
         region_studied_filename = os.path.join(
@@ -357,6 +376,7 @@ class TestTranslation(unittest.TestCase):
             expected_fhir_json = json.load(expected_output_file)
             self.assertEqual(actual_fhir_json, expected_fhir_json)
 
+    @ignore_warnings
     def test_region_studied_only(self):
         region_studied_filename = os.path.join(
             os.path.dirname(__file__), 'RegionsStudied_example4.bed')
@@ -371,6 +391,7 @@ class TestTranslation(unittest.TestCase):
             region_studied_filename=region_studied_filename)
         o_vcf_2_fhir.convert(output_filename)
 
+    @ignore_warnings
     def test_empty_fhir_json(self):
         conv_region_filename = os.path.join(os.path.dirname(
             __file__), 'RegionsToConvert_empty_example4.bed')
@@ -385,6 +406,7 @@ class TestTranslation(unittest.TestCase):
             conv_region_filename=conv_region_filename)
         o_vcf_2_fhir.convert(output_filename)
 
+    @ignore_warnings
     def test_tabix(self):
         self.maxDiff = None
         region_studied_filename = os.path.join(
@@ -461,6 +483,7 @@ class TestLogger(unittest.TestCase):
     # def tearDownClass(self):
     #     shutil.rmtree(self.LOG_DIR)
 
+    @ignore_warnings
     def test_logger_forks(self):
         region_studied_filename = os.path.join(
             os.path.dirname(__file__), 'RegionsStudied_example3.bed')

--- a/vcf2fhir/test/test_unit.py
+++ b/vcf2fhir/test/test_unit.py
@@ -8,6 +8,7 @@ suite = doctest.DocTestSuite(vcf2fhir)
 
 class TestChromIdentifier(unittest.TestCase):
 
+    @ignore_warnings
     def test_chrom_1_22(self):
         actual_chrom = ['chr1', '1', 'CHR1', '22', 'CHR22', 'chr22']
         expected_chrom = ['1', '1', '1', '22', '22', '22']
@@ -17,6 +18,7 @@ class TestChromIdentifier(unittest.TestCase):
                 chrom), expected_chrom[i])
             i += 1
 
+    @ignore_warnings
     def test_chrom_X_Y(self):
         actual_chrom = ['chrX', 'X', 'x', 'CHRX', 'chrY', 'Y', 'Y', 'CHRY']
         expected_chrom = ['X', 'X', 'X', 'X', 'Y', 'Y', 'Y', 'Y']
@@ -26,6 +28,7 @@ class TestChromIdentifier(unittest.TestCase):
                 chrom), expected_chrom[i])
             i += 1
 
+    @ignore_warnings
     def test_chrom_M(self):
         actual_chrom = ['MT', 'm', 'M', 'mt', 'chrm', 'chrM', 'chrmt', 'chrMT']
         expected_chrom = ['M', 'M', 'M', 'M', 'M', 'M', 'M', 'M']
@@ -35,6 +38,7 @@ class TestChromIdentifier(unittest.TestCase):
                 chrom), expected_chrom[i])
             i += 1
 
+    @ignore_warnings
     def test_chrom_validation(self):
         actual_chrom = [
             'chrX',
@@ -79,6 +83,7 @@ class TestChromIdentifier(unittest.TestCase):
 
 class TestDataType(unittest.TestCase):
 
+    @ignore_warnings
     def test_validate_ratio_ad_dp(self):
         ratio_ad_dp = [0.2, 0.65, 0.99, 1.3, -0.7, "Chr", False, True]
         valid = [True, True, True, False, False, False, False, False]
@@ -88,6 +93,7 @@ class TestDataType(unittest.TestCase):
                 value), valid[i])
             i += 1
 
+    @ignore_warnings
     def test_validate_has_tabix(self):
         has_tabix = [True, False, 1, 23.4, 'C', "CHROM"]
         valid = [True, True, False, False, False, False]


### PR DESCRIPTION
## Description

After resolving the Resource warnings due to the files not being closed in `test_integration.py` and the warning for `np.float` being deprecated in NumPy 1.20, the only warnings remaining were due to the libraries, `pyranges` and `unittest` which can be safely ignored. To do this, I added a decorator to ignore the remaining resource warnings. After making all the changes we get a clean looking output for `python -m unittest` as shown below:
![Screenshot 2021-04-09 at 4 54 24 PM](https://user-images.githubusercontent.com/47586886/114260616-b5bb8480-99f3-11eb-9d2f-351694a13fac.jpg)

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
