### PR TITLE
Updated the location of pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-
 ## Description
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


### PR DESCRIPTION
## Description

The `pull request template` was not working when kept inside `.github/PULL_REQUEST_TEMPLATE/`.
Moved the template to `.github/` to make it functioning.

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation