### PR TITLE
Fixed FHIR Validation errors and warnings

### DIFF
--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -43,7 +43,7 @@ class _Fhir_Helper:
                     {
                         "system": "http://loinc.org",
                         "code": "51959-5",
-                        "display": "Ranges-examined component"
+                        "display": "Range(s) of DNA sequence examined"
                     }
                 ]
             }
@@ -81,9 +81,10 @@ class _Fhir_Helper:
                 {
                     "coding": [
                         {
-                            "system": "http://loinc.org",
-                            "code": "TBD-UncallableRegions",
-                            "display": "Uncallable region"
+                            "system": ("http://hl7.org/fhir/uv/genomics" +
+                                       "-reporting/CodeSystem/TbdCodes"),
+                            "code": "uncallable-regions",
+                            "display": "Uncallable Regions"
                         }
                     ]
                 }
@@ -113,6 +114,17 @@ class _Fhir_Helper:
                                 ("http://hl7.org/fhir/uv/genomics-reporting" +
                                  "/StructureDefinition/genomics-report")]})
         self.report.status = "final"
+        self.report.category = concept.CodeableConcept(
+            {
+                "coding": [
+                    {
+                        "system": ("http://terminology.hl7.org/" +
+                                   "CodeSystem/v2-0074"),
+                        "code": "GE"
+                    }
+                ]
+            }
+        )
         self.report.code = concept.CodeableConcept(
             {
                 "coding": [
@@ -402,7 +414,7 @@ class _Fhir_Helper:
                 "coding": [
                     {
                         "system": ("http://hl7.org/fhir/uv/" +
-                                   "genomics-reporting/CodeSystem/tbd-codes"),
+                                   "genomics-reporting/CodeSystem/TbdCodes"),
                         "code": "exact-start-end",
                         "display": "Variant exact start and end"}]})
         observation_dv_component7.valueRange = valRange.Range(
@@ -457,8 +469,8 @@ class _Fhir_Helper:
                     "coding": [
                         {
                             "system": ("http://hl7.org/fhir/uv/" +
-                                       "genomics-reporting/" +
-                                       "CodeSystem/seq-phase-relationship"),
+                                       "genomics-reporting/CodeSystem/" +
+                                       "SequencePhaseRelationshipCS"),
                             "code": self.sequence_rels.at[index, 'Relation'],
                             "display":self.sequence_rels.at[index, 'Relation']
                         }
@@ -485,6 +497,10 @@ class _Fhir_Helper:
         else:
             od["contained"] = []
         od["status"] = response['status']
+        od['category'] = []
+        od['category'].append(response['category'])
+        od['category'][0]['coding'][0] =\
+            createOrderedDict(od['category'][0]['coding'][0], CG_ORDER)
         od["code"] = response['code']
         od["subject"] = response['subject']
         od["issued"] = response['issued']

--- a/vcf2fhir/test/expected_HG00403A.json
+++ b/vcf2fhir/test/expected_HG00403A.json
@@ -84,7 +84,7 @@
               {
                 "system": "http://loinc.org",
                 "code": "51959-5",
-                "display": "Ranges-examined component"
+                "display": "Range(s) of DNA sequence examined"
               }
             ]
           },
@@ -102,6 +102,16 @@
     }
   ],
   "status": "final",
+  "category": [
+        {
+            "coding": [
+                {
+                    "code": "GE",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074"
+                }
+            ]
+        }
+    ],
   "code": {
     "coding": [
       {

--- a/vcf2fhir/test/expected_example1_with_patient.json
+++ b/vcf2fhir/test/expected_example1_with_patient.json
@@ -135,7 +135,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -277,7 +277,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -419,7 +419,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -561,7 +561,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -703,7 +703,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -845,7 +845,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -987,7 +987,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -1129,7 +1129,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -1177,7 +1177,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Trans",
                         "display": "Trans"
                     }
@@ -1194,6 +1194,16 @@
         }
     ],
     "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                    "code": "GE"
+                }
+            ]
+        }
+    ],
     "code": {
         "coding": [
             {

--- a/vcf2fhir/test/expected_example1_wo_patient.json
+++ b/vcf2fhir/test/expected_example1_wo_patient.json
@@ -135,7 +135,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -277,7 +277,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -419,7 +419,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -561,7 +561,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -703,7 +703,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -845,7 +845,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -987,7 +987,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -1129,7 +1129,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -1177,7 +1177,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Trans",
                         "display": "Trans"
                     }
@@ -1194,6 +1194,16 @@
         }
     ],
     "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                    "code": "GE"
+                }
+            ]
+        }
+    ],
     "code": {
         "coding": [
             {

--- a/vcf2fhir/test/expected_example3.json
+++ b/vcf2fhir/test/expected_example3.json
@@ -84,7 +84,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -103,7 +103,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -120,9 +120,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://loinc.org",
-                                "code": "TBD-UncallableRegions",
-                                "display": "Uncallable region"
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "uncallable-regions",
+                                "display": "Uncallable Regions"
                             }
                         ]
                     },
@@ -265,7 +265,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -407,7 +407,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -549,7 +549,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -691,7 +691,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -782,7 +782,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -925,7 +925,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -973,7 +973,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Cis",
                         "display": "Cis"
                     }
@@ -1022,7 +1022,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Cis",
                         "display": "Cis"
                     }
@@ -1039,6 +1039,16 @@
         }
     ],
     "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                    "code": "GE"
+                }
+            ]
+        }
+    ],
     "code": {
         "coding": [
             {

--- a/vcf2fhir/test/expected_example4.json
+++ b/vcf2fhir/test/expected_example4.json
@@ -84,7 +84,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -101,9 +101,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://loinc.org",
-                                "code": "TBD-UncallableRegions",
-                                "display": "Uncallable region"
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "uncallable-regions",
+                                "display": "Uncallable Regions"
                             }
                         ]
                     },
@@ -195,7 +195,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -287,7 +287,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -379,7 +379,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -471,7 +471,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -563,7 +563,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -655,7 +655,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -747,7 +747,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -839,7 +839,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -931,7 +931,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1023,7 +1023,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1115,7 +1115,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1207,7 +1207,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1299,7 +1299,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1391,7 +1391,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1483,7 +1483,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1575,7 +1575,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1667,7 +1667,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1759,7 +1759,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1851,7 +1851,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -1943,7 +1943,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -2035,7 +2035,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -2127,7 +2127,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -2270,7 +2270,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -2412,7 +2412,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -2554,7 +2554,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -2696,7 +2696,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -2838,7 +2838,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -2980,7 +2980,7 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes",
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
                                 "code": "exact-start-end",
                                 "display": "Variant exact start and end"
                             }
@@ -3071,7 +3071,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -3163,7 +3163,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "51959-5",
-                                "display": "Ranges-examined component"
+                                "display": "Range(s) of DNA sequence examined"
                             }
                         ]
                     },
@@ -3212,7 +3212,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Cis",
                         "display": "Cis"
                     }
@@ -3261,7 +3261,7 @@
             "valueCodeableConcept": {
                 "coding": [
                     {
-                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/seq-phase-relationship",
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/SequencePhaseRelationshipCS",
                         "code": "Cis",
                         "display": "Cis"
                     }
@@ -3278,6 +3278,16 @@
         }
     ],
     "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                    "code": "GE"
+                }
+            ]
+        }
+    ],
     "code": {
         "coding": [
             {


### PR DESCRIPTION
## Description

Changed `display` and `codeSystem` according to the new **balloted specification**, and added a `DiagnosticReport.category` component to fix all the **FHIR** validation **errors** and **warnings**.

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation