### PR TITLE
Updated installation guide with steps for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 VCF-formatted files are the lingua franca of next-generation sequencing, whereas [HL7 FHIR](https://www.hl7.org/fhir/) is emerging as a standard language for electronic health record interoperability. A growing number of clinical genomics applications are emerging, based on the [HL7 FHIR Genomics standard](http://hl7.org/fhir/uv/genomics-reporting/index.html). Here, we provide an open source utility for converting variants from VCF format into HL7 FHIR Genomics format. Details of the translation logic are on the [manual page](docs/Manual.md). Additional information and case studies are described in our [BMC Bioinformatics article](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-021-04039-1). Conceptually, the utility takes a VCF as input and outputs a [FHIR Genomics report](http://hl7.org/fhir/uv/genomics-reporting/index.html). 
 
 ### Install
+Install and add [Ubuntu WSL](https://www.microsoft.com/en-in/p/ubuntu-1804-lts/9n9tngvndl3q?rtc=1&activetab=pivot:overviewtab) to the [windows terminal](https://www.microsoft.com/en-in/p/windows-terminal/9n0dx20hk701?activetab=pivot:overviewtab). (Only for windows users!)
+
 Before installing vcf2fhir you need to install cython and wheel.
 ```
 pip install cython wheel

--- a/docs/QUICKSTART.rst
+++ b/docs/QUICKSTART.rst
@@ -11,6 +11,8 @@ Installation
 
 Installing vcf2fhir is pretty simple. Here is a step by step plan on how to do it.
 
+Install and add `Ubuntu WSL <https://www.microsoft.com/en-in/p/ubuntu-1804-lts/9n9tngvndl3q?rtc=1&activetab=pivot:overviewtab>`_ to the `windows terminal <https://www.microsoft.com/en-in/p/windows-terminal/9n0dx20hk701?activetab=pivot:overviewtab>`_. (Only for windows users!)
+
 .. note::
     vcf2fhir is available on Pypi as ``vcf2fhir``.
 


### PR DESCRIPTION
## Description

Updated the installation guide in `README.md` and `QUIKSTART.rst` with steps on how to install `vcf2fhir` on **`windows`**.

Fixes #70

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation