### PR TITLE
Fixed base conversion for Conversion Region Disctionary

### DIFF
--- a/vcf2fhir/converter.py
+++ b/vcf2fhir/converter.py
@@ -39,8 +39,8 @@ class Converter(object):
     file (conv_region_filename):
 
        **conv_region_dict** : Array of regions (e.g. '{"Chromosome":
-       ["X", "X", "M"],"Start": [50001, 55001, 50001],"End": [52001,
-       60601, 60026]}'). Values for Chromosome must align with values in
+       ["X", "X", "M"],"Start": [50000, 55000, 50000],"End": [52000,
+       60600, 60025]}'). Values for Chromosome must align with values in
        VCF #CHROM field. Ranges must be `0-based \
        <https://www.biostars.org/p/84686/>`_
        (or 0-start, half-open) and based on GRCh37 or GRCh38 \
@@ -141,7 +141,6 @@ class Converter(object):
                     "Please provide valid 'conv_region_filename'")
         elif conv_region_dict:
             try:
-                self._fix_conv_region_zero_based(conv_region_dict)
                 self.conversion_region = pyranges.from_dict(conv_region_dict)
             except FileNotFoundError:
                 raise
@@ -198,16 +197,6 @@ class Converter(object):
             self.ratio_ad_dp,
             output_filename)
         general_logger.info("Completed VCF to FHIR Conversion")
-
-    def _fix_conv_region_zero_based(self, conv_region_dict):
-        i = 0
-        for start in conv_region_dict["Start"]:
-            conv_region_dict["Start"][i] = start - 1
-            i += 1
-        i = 0
-        for end in conv_region_dict["End"]:
-            conv_region_dict["End"][i] = end - 1
-            i += 1
 
     def _generate_exception(self, msg):
         general_logger.error(msg, exc_info=True)

--- a/vcf2fhir/test/test_integration.py
+++ b/vcf2fhir/test/test_integration.py
@@ -124,8 +124,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
     def test_conv_region_dict(self):
         conv_region_dict = {
             "Chromosome": ["X", "X", "M"],
-            "Start": [50001, 55001, 50001],
-            "End": [52001, 60601, 60026]
+            "Start": [50000, 55000, 50000],
+            "End": [52000, 60600, 60025]
         }
         o_vcf_2_fhir = vcf2fhir.Converter(
             os.path.join(
@@ -281,8 +281,8 @@ class TestTranslation(unittest.TestCase):
     def test_region_studied_dict(self):
         conv_region_dict = {
             "Chromosome": ["X", "X", "M"],
-            "Start": [50001, 55001, 50001],
-            "End": [52001, 60601, 60026]
+            "Start": [50000, 55000, 50000],
+            "End": [52000, 60600, 60025]
         }
         self.maxDiff = None
         region_studied_filename = os.path.join(


### PR DESCRIPTION
## Description

The **ranges** of Chromosomes to be converted(supplied via a **Conversion Region Dictionary**) must be `0-based`. Therefore, there is no need to decrement the `start` and the `end` by **one**.

Fixes #73 

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
