### PR TITLE
Updated logic for simple variant extraction

### DIFF
--- a/vcf2fhir/json_generator.py
+++ b/vcf2fhir/json_generator.py
@@ -210,7 +210,7 @@ def _get_fhir_json(
                         not conversion_region or
                         conversion_region[
                             record.CHROM,
-                            record.POS - 1: record.POS
+                            record.POS - 1: (record.POS + len(record.REF) - 1)
                         ].empty is False):
                     _add_record_variants(
                         record, ref_seq, patientID, fhir_helper, ratio_ad_dp)


### PR DESCRIPTION
## Description

Updated the **simple variant extraction logic** for the case where the `vcf` file isn't `tabix indexed` to also consider the **length** of the **REF** **allele**.

Fixes #74

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
