### PR TITLE
Adds support for the conversion of Structural Variants

### DIFF
--- a/vcf2fhir/common.py
+++ b/vcf2fhir/common.py
@@ -6,10 +6,33 @@ import pytz
 import logging
 import re
 from collections import OrderedDict
+from enum import Enum
 
 
 general_logger = logging.getLogger("vcf2fhir.general")
-
+SVs = {'INS', 'DEL', 'DUP', 'CNV', 'INV'}
+VARIANT_COMPONENTS_ORDER = [
+    'dna_change_type_component',
+    'ref_seq_id_component', 'genomic_source_class_component',
+    'allelic_state_component', 'allelic_frequency_component',
+    'copy_number_component', 'ref_allele_component', 'alt_allele_component',
+    'genomic_coord_system_component', 'exact_start_end_component',
+    'outer_start_end_component', 'inner_start_end_component',
+]
+GERMLINE = 'Germline'
+SOMATIC = 'Somatic'
+MIXED = 'Mixed'
+SVTYPE_TO_DNA_CHANGE_TYPE = {
+    'CNV': ['SO:0001019', 'copy_number_variation'],
+    'DUP': ['SO:1000035', 'duplication'],
+    'INV': ['SO:1000036', 'inversion'],
+    'DEL': ['SO:0000159', 'deletion'],
+    'INS': ['SO:0000667', 'insertion']
+}
+GENOMIC_SOURCE_CLASS_TO_CODE = {
+    GERMLINE: 'LA6683-2',
+    SOMATIC: 'LA6684-0'
+}
 
 """
 /**
@@ -17,6 +40,17 @@ general_logger = logging.getLogger("vcf2fhir.general")
  * @return date
  */
 """
+
+
+class Genomic_Source_Class(Enum):
+
+    @classmethod
+    def set_(cls):
+        return set(map(lambda c: c.value, cls))
+
+    GERMLINE = GERMLINE
+    SOMATIC = SOMATIC
+    MIXED = MIXED
 
 
 def get_fhir_date():
@@ -61,6 +95,7 @@ def get_sequence_relation(phased_rec_map):
 def get_allelic_state(record, ratio_ad_dp):
     allelic_state = ''
     allelic_code = ''
+    allelic_frequency = None
     # Using  the first sample
     sample = record.samples[0]
     alleles = sample.gt_alleles
@@ -85,8 +120,10 @@ def get_allelic_state(record, ratio_ad_dp):
                    len(sample.data.AD) > 0):
                     ratio = float(
                         sample.data.AD[0]) / float(sample.data.DP)
+                    allelic_frequency = ratio
                 else:
                     ratio = float(sample.data.AD) / float(sample.data.DP)
+                    allelic_frequency = ratio
                 if ratio > ratio_ad_dp:
                     allelic_state = "homoplasmic"
                     allelic_code = "LA6704-6"
@@ -101,7 +138,11 @@ def get_allelic_state(record, ratio_ad_dp):
             _error_log_allelicstate(record)
     else:
         _error_log_allelicstate(record)
-    return {'ALLELE': allelic_state, 'CODE': allelic_code}
+    return {
+                'ALLELE': allelic_state,
+                'CODE': allelic_code,
+                'FREQUENCY': allelic_frequency
+            }
 
 
 def extract_chrom_identifier(chrom):
@@ -148,6 +189,16 @@ def _error_log_allelicstate(record):
         "Cannot Determine AllelicState for: %s , considered sample: %s",
         record,
         record.samples[0].data)
+
+
+def get_dna_chg(svtype):
+    dna_chg = SVTYPE_TO_DNA_CHANGE_TYPE.get(svtype)
+    return {"CODE": dna_chg[0], "DISPLAY": dna_chg[1]}
+
+
+def get_genomic_source_class(genomic_source_class):
+    source_class_code = GENOMIC_SOURCE_CLASS_TO_CODE.get(genomic_source_class)
+    return {"CODE": source_class_code, "DISPLAY": genomic_source_class}
 
 
 def createOrderedDict(value_from, order):

--- a/vcf2fhir/common.py
+++ b/vcf2fhir/common.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import pandas as pd
+import fhirclient.models.codeableconcept as concept
 import pytz
 import logging
 import re
@@ -75,15 +76,13 @@ def get_allelic_state(record, ratio_ad_dp):
             allelic_code = 'LA6707-9'
         else:
             _error_log_allelicstate(record)
-    elif (
-            sample.gt_type is not None and
-            len(alleles) == 1 and
-            alleles[0] == '1'):
+    elif (sample.gt_type is not None and
+          len(alleles) == 1 and
+          alleles[0] == '1'):
         if hasattr(sample.data, 'AD') and hasattr(sample.data, 'DP'):
             try:
-                if(
-                        isinstance(sample.data.AD, list) and
-                        len(sample.data.AD) > 0):
+                if(isinstance(sample.data.AD, list) and
+                   len(sample.data.AD) > 0):
                     ratio = float(
                         sample.data.AD[0]) / float(sample.data.DP)
                 else:
@@ -133,6 +132,15 @@ def validate_has_tabix(has_tabix):
     if not isinstance(has_tabix, bool):
         return False
     return True
+
+
+def get_codeable_concept(system, code, display=None):
+    codeable_concept = {"coding": [{}]}
+    codeable_concept['coding'][0]['system'] = system
+    codeable_concept['coding'][0]['code'] = code
+    if display is not None:
+        codeable_concept['coding'][0]['display'] = display
+    return concept.CodeableConcept(codeable_concept)
 
 
 def _error_log_allelicstate(record):

--- a/vcf2fhir/converter.py
+++ b/vcf2fhir/converter.py
@@ -81,6 +81,12 @@ class Converter(object):
     If allelic depth (FORMAT.AD) / read depth (FORMAT.DP) is \
     greater than ratio_ad_dp then allelic state is
     homoplasmic; else heteroplasmic.
+
+    **genomic_source_class** (optional)(default value = somatic): An \
+    assertion as to whether variants in the VCF file are in the \
+    germline (i.e. inherited), somatic (e.g. arose spontaneously \
+    as cancer mutations), or mixed (i.e. may be a combination of \
+    germline and/or somatic).
     Returns
     -------
 
@@ -90,16 +96,10 @@ class Converter(object):
     """
 
     def __init__(
-            self,
-            vcf_filename=None,
-            ref_build=None,
-            patient_id=None,
-            has_tabix=False,
-            conv_region_filename=None,
-            conv_region_dict=None,
-            region_studied_filename=None,
-            nocall_filename=None,
-            ratio_ad_dp=0.99):
+            self, vcf_filename=None, ref_build=None, patient_id=None,
+            has_tabix=False, conv_region_filename=None, conv_region_dict=None,
+            region_studied_filename=None, nocall_filename=None,
+            ratio_ad_dp=0.99, genomic_source_class='somatic'):
 
         super(Converter, self).__init__()
         if not (vcf_filename):
@@ -167,12 +167,18 @@ class Converter(object):
         if not validate_ratio_ad_dp(ratio_ad_dp):
             raise Exception("Please provide a valid 'ratio_ad_dp'")
 
+        if genomic_source_class.title() not in Genomic_Source_Class.set_():
+            raise Exception(
+                ("Please provide a valid Genomic Source Class " +
+                 "('germline' or 'somatic' or 'mixed')"))
+
         self.ratio_ad_dp = ratio_ad_dp
         self.has_tabix = has_tabix
         self.patient_id = patient_id
         self.ref_build = ref_build
         self.nocall_filename = nocall_filename
         self.conv_region_filename = conv_region_filename
+        self.genomic_source_class = genomic_source_class.title()
         general_logger.info("Converter class instantiated successfully")
 
     def convert(self, output_filename='fhir.json'):
@@ -187,15 +193,9 @@ class Converter(object):
         """
         general_logger.info("Starting VCF to FHIR Conversion")
         _get_fhir_json(
-            self._vcf_reader,
-            self.ref_build,
-            self.patient_id,
-            self.has_tabix,
-            self.conversion_region,
-            self.region_studied,
-            self.nocall_region,
-            self.ratio_ad_dp,
-            output_filename)
+            self._vcf_reader, self.ref_build, self.patient_id, self.has_tabix,
+            self.conversion_region, self.region_studied, self.nocall_region,
+            self.ratio_ad_dp, self.genomic_source_class, output_filename)
         general_logger.info("Completed VCF to FHIR Conversion")
 
     def _generate_exception(self, msg):

--- a/vcf2fhir/json_generator.py
+++ b/vcf2fhir/json_generator.py
@@ -82,19 +82,12 @@ def _add_record_variants(record, ref_seq, patientID, fhir_helper, ratio_ad_dp):
 
 
 def _add_region_studied(
-        region_studied,
-        conversion_region,
-        nocall_region,
-        fhir_helper,
-        chrom,
-        ref_seq,
-        patientID):
-    if((
-            (region_studied and not region_studied[chrom].empty) or
-            (nocall_region and not nocall_region[chrom].empty)) or
-            (
-                (region_studied is not None and len(region_studied) == 0) and
-                (conversion_region and not conversion_region[chrom].empty))):
+        region_studied, conversion_region,
+        nocall_region, fhir_helper, chrom, ref_seq, patientID):
+    if(((region_studied and not region_studied[chrom].empty) or
+       (nocall_region and not nocall_region[chrom].empty)) or
+       ((region_studied is not None and len(region_studied) == 0) and
+       (conversion_region and not conversion_region[chrom].empty))):
         general_logger.info("Adding region Studied observation for %s", chrom)
         general_logger.debug("Region Examined %s", region_studied[chrom])
         general_logger.debug("Region Uncallable %s", nocall_region[chrom])
@@ -136,13 +129,8 @@ def _get_fhir_json(
             ref_seq = _get_ref_seq_by_chrom(
                 ref_build, extract_chrom_identifier(chrom))
             _add_region_studied(
-                region_studied,
-                conversion_region,
-                nocall_region,
-                fhir_helper,
-                chrom,
-                ref_seq,
-                patientID
+                region_studied, conversion_region,
+                nocall_region, fhir_helper, chrom, ref_seq, patientID
             )
             if conversion_region and not conversion_region[chrom].empty:
                 for _, row in conversion_region[chrom].df.iterrows():
@@ -195,13 +183,8 @@ def _get_fhir_json(
                         current_ref_seq = _get_ref_seq_by_chrom(
                             ref_build, chrom)
                         _add_region_studied(
-                            region_studied,
-                            conversion_region,
-                            nocall_region,
-                            fhir_helper,
-                            chrom,
-                            current_ref_seq,
-                            patientID)
+                            region_studied, conversion_region, nocall_region,
+                            fhir_helper, chrom, current_ref_seq, patientID)
                         prev_add_chrom = chrom
                         chrom_index += 1
                         chrom = _get_chrom(chrom_index)

--- a/vcf2fhir/json_generator.py
+++ b/vcf2fhir/json_generator.py
@@ -7,7 +7,7 @@ invalid_record_logger = logging.getLogger("vcf2fhir.invalidrecord")
 general_logger = logging.getLogger("vcf2fhir.general")
 
 
-def _valid_record(record):
+def _valid_record(record, genomic_source_class):
     if not (validate_chrom_identifier(record.CHROM)):
         invalid_record_logger.debug(
             ("Reason: VCF CHROM is not recognized, " +
@@ -15,14 +15,48 @@ def _valid_record(record):
             record,
             record.samples[0].data)
         return False
-    if(record.is_sv):
-        invalid_record_logger.debug(
-            ("Reason: VCF INFO.SVTYPE is present. " +
-             "(Structural variants are excluded), " +
-             "Record: %s, considered sample: %s"),
-            record,
-            record.samples[0].data)
-        return False
+    if record.is_sv:
+        if len(record.samples) > 1:
+            invalid_record_logger.debug(
+                ("Reason: Multi-sample VCFs for SVs are not allowed, " +
+                 "Record: %s, considered sample: %s"),
+                record,
+                record.samples[0].data)
+            return False
+        if(record.INFO['SVTYPE'] not in list(SVs)):
+            invalid_record_logger.debug(
+                ("Reason: VCF INFO.SVTYPE must be in ['INS', 'DEL', " +
+                 "'DUP', 'CNV', 'INV']. Record: %s, considered sample: %s"),
+                record,
+                record.samples[0].data)
+            return False
+        # The following if condition checks if RECORD.ALT is a
+        # '.' or simple character string or comma-separated character string or
+        # angle-bracketed token or comma separated angle-bracketed token,
+        # for structural variants.
+        if(not all(alt is None or alt.type in ['SNV', 'MNV'] or
+           isinstance(alt, vcf.model._SV) for alt in record.ALT)):
+            invalid_record_logger.debug(
+                ("Reason: ALT is not a simple character string, " +
+                 "comma-separated character string, angle-bracketed token, " +
+                 "comma separated angle-bracketed token " +
+                 "list or '.', Record: %s, considered sample: %s"),
+                record,
+                record.samples[0].data)
+            return False
+    else:
+        # The following if condition checks if RECORD.ALT is a
+        # '.' or simple character string or comma-separated character string,
+        # for simple variants.
+        if(not all(alt is None or alt.type in ['SNV', 'MNV']
+           for alt in record.ALT)):
+            invalid_record_logger.debug(
+                ("Reason: ALT is not a simple character string, " +
+                 "comma-separated character string " +
+                 "or '.', Record: %s, considered sample: %s"),
+                record,
+                record.samples[0].data)
+            return False
     if(record.FILTER is not None and len(record.FILTER) != 0):
         invalid_record_logger.debug(
             ("Reason: VCF FILTER does not equal " +
@@ -30,20 +64,25 @@ def _valid_record(record):
             record,
             record.samples[0].data)
         return False
-    if(len(record.samples) == 0 or record.samples[0].gt_type is None):
+    # The following if condition checks if FORMAT.GT contains '.' when
+    # genomic source class is 'germline' for simple variants and Structural
+    # variants with SVTYPE in ['INV', 'DEL', 'INS'].
+    if((len(record.samples) == 0 or record.samples[0].gt_type is None) or
+        record.samples[0]['GT'] in ['0/0', '0|0', '0'] or
+        ((((not record.is_sv or (record.is_sv and
+            record.INFO['SVTYPE'] in list(SVs - {'DUP', 'CNV'})))) and
+            '.' in record.samples[0]['GT'] and
+            genomic_source_class == Genomic_Source_Class.GERMLINE.value))):
         invalid_record_logger.debug(
             ("Reason: VCF FORMAT.GT is null ('./.', '.|.', '.', etc), " +
              "Record: %s, considered sample: %s"),
             record,
             record.samples[0].data)
         return False
-    if(
-            len(record.ALT) != 1 or
-            (record.ALT[0].type != 'SNV' and record.ALT[0].type != 'MNV')):
+    if not record.REF.isalpha():
         invalid_record_logger.debug(
-            ("Reason: ALT is not a simple character string, comma-separated " +
-             "character string or '.' (Rows where ALT is a token " +
-             "(e.g. 'DEL') are excluded), Record: %s, considered sample: %s"),
+            ("Reason: REF is not a simple character string. " +
+             "Record: %s, considered sample: %s"),
             record,
             record.samples[0].data)
         return False
@@ -76,9 +115,12 @@ def _fix_regions_chrom(region):
             extract_chrom_identifier)
 
 
-def _add_record_variants(record, ref_seq, patientID, fhir_helper, ratio_ad_dp):
-    if(_valid_record(record)):
-        fhir_helper.add_variant_obv(record, ref_seq, ratio_ad_dp)
+def _add_record_variants(
+        record,
+        ref_seq, patientID, fhir_helper, ratio_ad_dp, genomic_source_class):
+    if(_valid_record(record, genomic_source_class)):
+        fhir_helper.add_variant_obv(
+            record, ref_seq, ratio_ad_dp, genomic_source_class)
 
 
 def _add_region_studied(
@@ -97,14 +139,8 @@ def _add_region_studied(
 
 def _get_fhir_json(
         vcf_reader,
-        ref_build,
-        patientID,
-        has_tabix,
-        conversion_region,
-        region_studied,
-        nocall_region,
-        ratio_ad_dp,
-        output_filename):
+        ref_build, patientID, has_tabix, conversion_region, region_studied,
+        nocall_region, ratio_ad_dp, genomic_source_class, output_filename):
     fhir_helper = _Fhir_Helper(patientID)
     fhir_helper.initalize_report()
     general_logger.debug("Finished Initializing empty report")
@@ -145,11 +181,8 @@ def _get_fhir_json(
                             record.CHROM = extract_chrom_identifier(
                                 record.CHROM)
                             _add_record_variants(
-                                record,
-                                ref_seq,
-                                patientID,
-                                fhir_helper,
-                                ratio_ad_dp
+                                record, ref_seq, patientID,
+                                fhir_helper, ratio_ad_dp, genomic_source_class
                             )
             elif not conversion_region:
                 vcf_iterator = None
@@ -162,11 +195,8 @@ def _get_fhir_json(
                         record.CHROM = extract_chrom_identifier(
                             record.CHROM)
                         _add_record_variants(
-                            record,
-                            ref_seq,
-                            patientID,
-                            fhir_helper,
-                            ratio_ad_dp
+                            record, ref_seq, patientID,
+                            fhir_helper, ratio_ad_dp, genomic_source_class
                         )
     else:
         chrom_index = 1
@@ -189,14 +219,16 @@ def _get_fhir_json(
                         chrom_index += 1
                         chrom = _get_chrom(chrom_index)
                 ref_seq = _get_ref_seq_by_chrom(ref_build, record.CHROM)
-                if (
-                        not conversion_region or
-                        conversion_region[
-                            record.CHROM,
-                            record.POS - 1: (record.POS + len(record.REF) - 1)
-                        ].empty is False):
+                end = record.POS + len(record.REF) - 1
+                if record.is_sv and hasattr(record.INFO, 'END'):
+                    end = record.INFO['END']
+                if(not conversion_region or
+                   conversion_region[
+                        record.CHROM, record.POS - 1: end
+                   ].empty is False):
                     _add_record_variants(
-                        record, ref_seq, patientID, fhir_helper, ratio_ad_dp)
+                        record, ref_seq, patientID,
+                        fhir_helper, ratio_ad_dp, genomic_source_class)
 
     general_logger.info("Adding all the phased sequence relationship found")
     fhir_helper.add_phased_relationship_obv()

--- a/vcf2fhir/test/expected_HG00403A.json
+++ b/vcf2fhir/test/expected_HG00403A.json
@@ -1,133 +1,133 @@
 {
-  "resourceType": "DiagnosticReport",
-  "id": "",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genomics-report"
-    ]
-  },
-  "contained": [
-    {
-      "resourceType": "Observation",
-      "id": "",
-      "meta": {
+    "resourceType": "DiagnosticReport",
+    "id": "",
+    "meta": {
         "profile": [
-          "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied"
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/genomics-report"
         ]
-      },
-      "status": "final",
-      "category": [
+    },
+    "contained": [
         {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-              "code": "laboratory"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
-          {
-            "system": "http://loinc.org",
-            "code": "53041-0",
-            "display": "DNA region of interest panel"
-          }
-        ]
-      },
-      "subject": {
-        "reference": "Patient/GS000016660-ASM"
-      },
-      "component": [
-        {
-          "code": {
-            "coding": [
-              {
-                "system": "http://loinc.org",
-                "code": "92822-6",
-                "display": "Genomic coord system"
-              }
-            ]
-          },
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://loinc.org",
-                "code": "LA30102-0",
-                "display": "1-based character counting"
-              }
-            ]
-          }
-        },
-        {
-          "code": {
-            "coding": [
-              {
-                "system": "http://loinc.org",
-                "code": "48013-7",
-                "display": "Genomic reference sequence ID"
-              }
-            ]
-          },
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                "code": "NC_000001.10"
-              }
-            ]
-          }
-        },
-        {
-          "code": {
-            "coding": [
-              {
-                "system": "http://loinc.org",
-                "code": "51959-5",
-                "display": "Range(s) of DNA sequence examined"
-              }
-            ]
-          },
-          "dataAbsentReason": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
-                "code": "not-performed",
-                "display": "Not Performed"
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ],
-  "status": "final",
-  "category": [
-        {
-            "coding": [
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied"
+                ]
+            },
+            "status": "final",
+            "category": [
                 {
-                    "code": "GE",
-                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074"
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "53041-0",
+                        "display": "DNA region of interest panel"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/GS000016660-ASM"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000001.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "51959-5",
+                                "display": "Range(s) of DNA sequence examined"
+                            }
+                        ]
+                    },
+                    "dataAbsentReason": {
+                        "coding": [
+                            {
+                                "code": "not-performed",
+                                "display": "Not Performed",
+                                "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason"
+                            }
+                        ]
+                    }
                 }
             ]
         }
     ],
-  "code": {
-    "coding": [
-      {
-        "system": "http://loinc.org",
-        "code": "81247-9",
-        "display": "Master HL7 genetic variant reporting panel"
-      }
+    "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                    "code": "GE"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://loinc.org",
+                "code": "81247-9",
+                "display": "Master HL7 genetic variant reporting panel"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/GS000016660-ASM"
+    },
+    "issued": "",
+    "result": [
+        {
+            "reference": ""
+        }
     ]
-  },
-  "subject": {
-    "reference": "Patient/GS000016660-ASM"
-  },
-  "issued": "",
-  "result": [
-    {
-      "reference": ""
-    }
-  ]
 }

--- a/vcf2fhir/test/expected_example1_with_patient.json
+++ b/vcf2fhir/test/expected_example1_with_patient.json
@@ -72,8 +72,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -81,434 +81,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "."
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 15
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/HG00628"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "A,T"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 16
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/HG00628"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": ""
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 20
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/HG00628"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -640,8 +214,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -649,8 +223,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6705-3",
-                                "display": "homozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -782,8 +356,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -791,8 +365,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -924,8 +498,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -933,8 +507,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -1066,8 +640,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -1075,8 +649,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -1218,15 +792,6 @@
     },
     "issued": "",
     "result": [
-        {
-            "reference": ""
-        },
-        {
-            "reference": ""
-        },
-        {
-            "reference": ""
-        },
         {
             "reference": ""
         },

--- a/vcf2fhir/test/expected_example1_wo_patient.json
+++ b/vcf2fhir/test/expected_example1_wo_patient.json
@@ -72,8 +72,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -81,434 +81,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "."
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 15
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/TEST001"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "A,T"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 16
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/TEST001"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69547-8",
-                                "display": "Genomic Ref allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": ""
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "69551-0",
-                                "display": "Genomic Alt allele [ID]"
-                            }
-                        ]
-                    },
-                    "valueString": "G"
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "92822-6",
-                                "display": "Genomic coord system"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA30102-0",
-                                "display": "1-based character counting"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
-                            }
-                        ]
-                    },
-                    "valueRange": {
-                        "low": {
-                            "value": 20
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "resourceType": "Observation",
-            "id": "",
-            "meta": {
-                "profile": [
-                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-                ]
-            },
-            "status": "final",
-            "category": [
-                {
-                    "coding": [
-                        {
-                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                            "code": "laboratory"
-                        }
-                    ]
-                }
-            ],
-            "code": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "69548-6",
-                        "display": "Genetic variant assessment"
-                    }
-                ]
-            },
-            "subject": {
-                "reference": "Patient/TEST001"
-            },
-            "valueCodeableConcept": {
-                "coding": [
-                    {
-                        "system": "http://loinc.org",
-                        "code": "LA9633-4",
-                        "display": "present"
-                    }
-                ]
-            },
-            "component": [
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "48013-7",
-                                "display": "Genomic reference sequence ID"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                "code": "NC_000001.10"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -640,8 +214,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -649,8 +223,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6705-3",
-                                "display": "homozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -782,8 +356,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -791,8 +365,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -924,8 +498,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -933,8 +507,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -1066,8 +640,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -1075,8 +649,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -1218,15 +792,6 @@
     },
     "issued": "",
     "result": [
-        {
-            "reference": ""
-        },
-        {
-            "reference": ""
-        },
-        {
-            "reference": ""
-        },
         {
             "reference": ""
         },

--- a/vcf2fhir/test/expected_example3.json
+++ b/vcf2fhir/test/expected_example3.json
@@ -202,8 +202,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -211,8 +211,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -344,8 +344,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -353,8 +353,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -486,8 +486,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -495,8 +495,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -628,8 +628,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -637,8 +637,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -862,8 +862,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -871,10 +871,26 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6703-8",
-                                "display": "heteroplasmic"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "81258-6",
+                                "display": "Sample VAF"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 0.8
                     }
                 },
                 {

--- a/vcf2fhir/test/expected_example4.json
+++ b/vcf2fhir/test/expected_example4.json
@@ -2207,8 +2207,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2216,8 +2216,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -2349,8 +2349,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2358,8 +2358,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -2491,8 +2491,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2500,8 +2500,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -2633,8 +2633,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2642,8 +2642,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -2775,8 +2775,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2784,8 +2784,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }
@@ -2917,8 +2917,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "53034-5",
-                                "display": "Allelic state"
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
                             }
                         ]
                     },
@@ -2926,8 +2926,8 @@
                         "coding": [
                             {
                                 "system": "http://loinc.org",
-                                "code": "LA6706-1",
-                                "display": "heterozygous"
+                                "code": "LA6684-0",
+                                "display": "Somatic"
                             }
                         ]
                     }

--- a/vcf2fhir/test/test_integration.py
+++ b/vcf2fhir/test/test_integration.py
@@ -225,7 +225,7 @@ class TestTranslation(unittest.TestCase):
             self,
             output_filename=output_filename,
             expected_output_filename=expected_output_filename,
-            dict={8: [5, 6]})
+            dict={5: [2, 3]})
 
     def test_with_patient_id(self):
         self.maxDiff = None
@@ -240,7 +240,7 @@ class TestTranslation(unittest.TestCase):
             self,
             output_filename=output_filename,
             expected_output_filename=expected_output_filename,
-            dict={8: [5, 6]})
+            dict={5: [2, 3]})
 
     # FIXME: just a temporary test, later change it to a test that test
     # particular variant

--- a/vcf2fhir/test/test_unit.py
+++ b/vcf2fhir/test/test_unit.py
@@ -37,39 +37,11 @@ class TestChromIdentifier(unittest.TestCase):
 
     def test_chrom_validation(self):
         actual_chrom = [
-            'chrX',
-            'R',
-            'mt',
-            'chrR',
-            'chrM',
-            'chrMT',
-            'chr30',
-            'P',
-            'Z',
-            '45',
-            'o',
-            'CHRX',
-            '1',
-            '22',
-            'CHR21',
-            'x']
+            'chrX', 'R', 'mt', 'chrR', 'chrM', 'chrMT',
+            'chr30', 'P', 'Z', '45', 'o', 'CHRX', '1', '22', 'CHR21', 'x']
         recognized = [
-            True,
-            False,
-            True,
-            False,
-            True,
-            True,
-            False,
-            False,
-            False,
-            False,
-            False,
-            True,
-            True,
-            True,
-            True,
-            True]
+            True, False, True, False, True, True,
+            False, False, False, False, False, True, True, True, True, True]
         i = 0
         for chrom in actual_chrom:
             self.assertEqual(validate_chrom_identifier(


### PR DESCRIPTION
## Description

- Updated the code to add support for the conversion of **`Structural Variants`**.
- Exposed a new parameter '**`genomic_source_class`**' to configure **Genomic Source Class**.

Fixes #11

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
