### PR TITLE
Updates Code to handle multi-valued alts and remove default value for Genomic Source Class

### DIFF
--- a/vcf2fhir/converter.py
+++ b/vcf2fhir/converter.py
@@ -89,7 +89,7 @@ class Converter(object):
     greater than ratio_ad_dp then allelic state is
     homoplasmic; else heteroplasmic.
 
-    **genomic_source_class** (optional)(default value = somatic): An \
+    **genomic_source_class** (required): An \
     assertion as to whether variants in the VCF file are in the \
     germline (i.e. inherited), somatic (e.g. arose spontaneously \
     as cancer mutations), or mixed (i.e. may be a combination of \
@@ -107,7 +107,7 @@ class Converter(object):
             has_tabix=False, conv_region_filename=None, conv_region_dict=None,
             annotation_filename=None, region_studied_filename=None,
             nocall_filename=None, ratio_ad_dp=0.99,
-            genomic_source_class='somatic'):
+            genomic_source_class=None):
 
         super(Converter, self).__init__()
         if not (vcf_filename):
@@ -119,6 +119,14 @@ class Converter(object):
             raise Exception(
                 ("Please also provide region_studied_filename " +
                  "when nocall_filename is provided"))
+        if not genomic_source_class:
+            raise Exception(
+                'You must provide Genomic Source Class("somatic" or "mixed")')
+        if(not isinstance(genomic_source_class, str) or
+           genomic_source_class.title() not in Genomic_Source_Class.set_()):
+            raise Exception(
+                ("Please provide a valid Genomic Source Class " +
+                 "('germline' or 'somatic' or 'mixed')"))
         self.vcf_filename = vcf_filename
         try:
             self._vcf_reader = vcf.Reader(filename=vcf_filename)
@@ -194,11 +202,6 @@ class Converter(object):
 
         if not validate_ratio_ad_dp(ratio_ad_dp):
             raise Exception("Please provide a valid 'ratio_ad_dp'")
-
-        if genomic_source_class.title() not in Genomic_Source_Class.set_():
-            raise Exception(
-                ("Please provide a valid Genomic Source Class " +
-                 "('germline' or 'somatic' or 'mixed')"))
 
         self.ratio_ad_dp = ratio_ad_dp
         self.has_tabix = has_tabix

--- a/vcf2fhir/test/expected_fhir_germline_structural.json
+++ b/vcf2fhir/test/expected_fhir_germline_structural.json
@@ -5670,6 +5670,1482 @@
                         "coding": [
                             {
                                 "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6683-2",
+                                "display": "Germline"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
                                 "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
                             }
                         ]
@@ -5887,6 +7363,42 @@
     },
     "issued": "",
     "result": [
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
         {
             "reference": ""
         },

--- a/vcf2fhir/test/expected_fhir_mixed_structural.json
+++ b/vcf2fhir/test/expected_fhir_mixed_structural.json
@@ -5250,6 +5250,1362 @@
                         "coding": [
                             {
                                 "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
                                 "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
                             }
                         ]
@@ -5447,6 +6803,42 @@
     },
     "issued": "",
     "result": [
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
         {
             "reference": ""
         },

--- a/vcf2fhir/test/expected_fhir_somatic_structural.json
+++ b/vcf2fhir/test/expected_fhir_somatic_structural.json
@@ -5730,6 +5730,1482 @@
                         "coding": [
                             {
                                 "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523948:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523949
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
+                                "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48019-4",
+                                "display": "DNA Change Type"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://sequenceontology.org",
+                                "code": "SO:0001019",
+                                "display": "copy_number_variation"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48013-7",
+                                "display": "Genomic reference sequence ID"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                "code": "NC_000022.10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48002-0",
+                                "display": "Genomic Source Class"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA6684-0",
+                                "display": "Somatic"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "82155-3",
+                                "display": "Genomic Structural Variant copy Number"
+                            }
+                        ]
+                    },
+                    "valueQuantity": {
+                        "system": "http://unitsofmeasure.org",
+                        "code": "1",
+                        "value": 3
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "69547-8",
+                                "display": "Genomic Ref allele [ID]"
+                            }
+                        ]
+                    },
+                    "valueString": "T"
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "92822-6",
+                                "display": "Genomic coord system"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "LA30102-0",
+                                "display": "1-based character counting"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                                "code": "inner-start-end",
+                                "display": "Variant inner start and end"
+                            }
+                        ]
+                    },
+                    "valueRange": {
+                        "high": {
+                            "value": 42533891
+                        },
+                        "low": {
+                            "value": 42523951
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/diagnostic-implication"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
+                        "code": "diagnostic-implication",
+                        "display": "Diagnostic Implication"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "53037-8",
+                                "display": "Genetic variation clinical significance [Imp]"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "display": "not specified"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "derivedFrom": [
+                {
+                    "reference": ""
+                }
+            ]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "",
+            "meta": {
+                "profile": [
+                    "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                ]
+            },
+            "status": "final",
+            "category": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                }
+            ],
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "69548-6",
+                        "display": "Genetic variant assessment"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/NA12877_S1"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LA9633-4",
+                        "display": "present"
+                    }
+                ]
+            },
+            "component": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "48004-6",
+                                "display": "DNA change (c.HGVS)"
+                            }
+                        ]
+                    },
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "http://varnomen.hgvs.org",
                                 "code": "NC_000022.10:42523950:T:<CN0><CN2><CN3><CN4>"
                             }
                         ]
@@ -5947,6 +7423,42 @@
     },
     "issued": "",
     "result": [
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
+        {
+            "reference": ""
+        },
         {
             "reference": ""
         },

--- a/vcf2fhir/test/test_integration.py
+++ b/vcf2fhir/test/test_integration.py
@@ -76,12 +76,15 @@ class TestVcf2FhirInputs(unittest.TestCase):
 
     def test_invalid_vcf_filename(self):
         self.assertRaises(FileNotFoundError,
-                          vcf2fhir.Converter, *['Hello', 'GRCh38'])
+                          vcf2fhir.Converter, *['Hello', 'GRCh38', None,
+                                                False, None, None, None,
+                                                None, None, 0.99, 'somatic'])
 
     def test_required_ref_build(self):
         with self.assertRaises(Exception) as context:
             vcf2fhir.Converter(os.path.join(
-                os.path.dirname(__file__), 'vcf_example1.vcf'))
+                os.path.dirname(__file__), 'vcf_example1.vcf'),
+                genomic_source_class='somatic')
         self.assertEqual(
             'You must provide build number ("GRCh37" or "GRCh38")', str(
                 context.exception))
@@ -89,19 +92,22 @@ class TestVcf2FhirInputs(unittest.TestCase):
     def test_invalid_ref_build(self):
         with self.assertRaises(Exception) as context:
             vcf2fhir.Converter(os.path.join(
-                os.path.dirname(__file__), 'vcf_example1.vcf'), 'b38')
+                os.path.dirname(__file__), 'vcf_example1.vcf'), 'b38',
+                genomic_source_class='somatic')
         self.assertEqual(
             'You must provide build number ("GRCh37" or "GRCh38")', str(
                 context.exception))
 
     def test_valid_ref_build_37(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
-            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37')
+            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37',
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_valid_ref_build_38(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
-            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh38')
+            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh38',
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_conv_region_only(self):
@@ -113,7 +119,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
                 'vcf_example3.vcf'),
             'GRCh37',
             'abc',
-            conv_region_filename=conv_region_filename)
+            conv_region_filename=conv_region_filename,
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_conv_region_dict(self):
@@ -128,7 +135,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
                 'vcf_example3.vcf'),
             'GRCh37',
             'abc',
-            conv_region_dict=conv_region_dict)
+            conv_region_dict=conv_region_dict,
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_conv_region_region_studied(self):
@@ -143,7 +151,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
             'GRCh37',
             'abc',
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_conv_region_nocall(self):
@@ -159,7 +168,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
                 'GRCh37',
                 'abc',
                 conv_region_filename=conv_region_filename,
-                nocall_filename=nocall_filename)
+                nocall_filename=nocall_filename,
+                genomic_source_class='somatic')
         self.assertEqual(
             ('Please also provide region_studied_filename ' +
              'when nocall_filename is provided'), str(
@@ -174,7 +184,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
                 'vcf_example3.vcf'),
             'GRCh37',
             'abc',
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            genomic_source_class='somatic')
         self.assertEqual(type(o_vcf_2_fhir), vcf2fhir.Converter)
 
     def test_no_conv_region_nocall(self):
@@ -187,7 +198,8 @@ class TestVcf2FhirInputs(unittest.TestCase):
                     'vcf_example3.vcf'),
                 'GRCh37',
                 'abc',
-                nocall_filename=nocall_filename)
+                nocall_filename=nocall_filename,
+                genomic_source_class='somatic')
         self.assertEqual(
             ('Please also provide region_studied_filename ' +
              'when nocall_filename is provided'), str(
@@ -210,7 +222,8 @@ class TestTranslation(unittest.TestCase):
     def test_wo_patient_id(self):
         self.maxDiff = None
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
-            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37')
+            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37',
+            genomic_source_class='somatic')
         output_filename = os.path.join(os.path.dirname(
             __file__), self.TEST_RESULT_DIR, 'fhir_wo_patient_example1.json')
         expected_output_filename = os.path.join(
@@ -225,7 +238,8 @@ class TestTranslation(unittest.TestCase):
     def test_with_patient_id(self):
         self.maxDiff = None
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(os.path.dirname(
-            __file__), 'vcf_example1.vcf'), 'GRCh37', 'HG00628')
+            __file__), 'vcf_example1.vcf'), 'GRCh37', 'HG00628',
+            genomic_source_class='somatic')
         output_filename = os.path.join(os.path.dirname(
             __file__), self.TEST_RESULT_DIR, 'fhir_with_patient_example1.json')
         expected_output_filename = os.path.join(os.path.dirname(
@@ -241,7 +255,8 @@ class TestTranslation(unittest.TestCase):
     # particular variant
     def test_anotherfile(self):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(os.path.dirname(
-            __file__), 'vcf_example2.vcf'), 'GRCh37', 'HG00628')
+            __file__), 'vcf_example2.vcf'), 'GRCh37', 'HG00628',
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename=os.path.join(
             os.path.dirname(__file__), self.TEST_RESULT_DIR, 'fhir2.json'))
 
@@ -265,7 +280,8 @@ class TestTranslation(unittest.TestCase):
             'HG00628',
             conv_region_filename=conv_region_filename,
             region_studied_filename=region_studied_filename,
-            nocall_filename=nocall_filename)
+            nocall_filename=nocall_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         _compare_actual_and_expected_fhir_json(
             self,
@@ -296,7 +312,8 @@ class TestTranslation(unittest.TestCase):
             'HG00628',
             conv_region_dict=conv_region_dict,
             region_studied_filename=region_studied_filename,
-            nocall_filename=nocall_filename)
+            nocall_filename=nocall_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         _compare_actual_and_expected_fhir_json(
             self,
@@ -326,7 +343,8 @@ class TestTranslation(unittest.TestCase):
             'HG00628',
             conv_region_filename=conv_region_filename,
             region_studied_filename=region_studied_filename,
-            nocall_filename=nocall_filename)
+            nocall_filename=nocall_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         _compare_actual_and_expected_fhir_json(
             self,
@@ -345,7 +363,8 @@ class TestTranslation(unittest.TestCase):
                 'vcf_example4.vcf'),
             'GRCh38',
             'HG00628',
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
 
     def test_empty_fhir_json(self):
@@ -359,7 +378,8 @@ class TestTranslation(unittest.TestCase):
                 'vcf_example4.vcf'),
             'GRCh38',
             'HG00628',
-            conv_region_filename=conv_region_filename)
+            conv_region_filename=conv_region_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
 
     def test_no_region_examined(self):
@@ -379,7 +399,8 @@ class TestTranslation(unittest.TestCase):
             'GRCh37',
             has_tabix=True,
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         _compare_actual_and_expected_fhir_json(
             self,
@@ -422,7 +443,7 @@ class TestTranslation(unittest.TestCase):
         o_vcf_2_fhir = vcf2fhir.Converter(os.path.join(
             os.path.dirname(__file__), 'vcf_structural_variants.vcf'),
             'GRCh37',
-            genomic_source_class='germline',)
+            genomic_source_class='germline')
         output_filename = os.path.join(os.path.dirname(
             __file__), self.TEST_RESULT_DIR, 'fhir_structural_germline.json')
         expected_output_filename = os.path.join(
@@ -490,7 +511,8 @@ class TestTranslation(unittest.TestCase):
             has_tabix=True,
             conv_region_filename=conv_region_filename,
             region_studied_filename=region_studied_filename,
-            nocall_filename=nocall_filename)
+            nocall_filename=nocall_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         _compare_actual_and_expected_fhir_json(
             self,
@@ -560,7 +582,8 @@ class TestLogger(unittest.TestCase):
             'HG00628',
             conv_region_filename=conv_region_filename,
             region_studied_filename=region_studied_filename,
-            nocall_filename=nocall_filename)
+            nocall_filename=nocall_filename,
+            genomic_source_class='somatic')
         o_vcf_2_fhir.convert(output_filename)
         self.assertEqual(os.path.exists(self.log_general_filename), True)
         self.assertEqual(os.path.exists(


### PR DESCRIPTION
## Description

This PR is a combination of two commits:

- Updates code to handle the case where a vcf record has **multiple alts**. Different **FHIR variants** must be created for each **ALT**.
- Removes default value(`Somatic`) for the `genomicSourceClass` parameter.

Fixes #96

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and the **PEP 8** formatting was validated using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
