### PR TITLE
variant inner end error fix and code-system update

### DIFF
--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -196,7 +196,7 @@ class _Fhir_Helper:
         if annotation_record['phenotype'] is not None:
             associated_phenotype_component = observation.ObservationComponent()
             associated_phenotype_component.code = get_codeable_concept(
-                "http://loinc.org", "81259-4", "Associated phenotype"
+                "http://loinc.org", "81259-4", "predicted phenotype"
             )
             associated_phenotype_component\
                 .valueCodeableConcept = get_codeable_concept(
@@ -282,14 +282,13 @@ class _Fhir_Helper:
             # only the INFO.END value.
             if hasattr(record.INFO, 'CIPOS') and hasattr(record.INFO, 'CIEND'):
                 inner_start = record.POS + record.INFO['CIPOS'][1]
-                inner_end = record.INFO['END'] + abs(record.INFO['CIEND'][0])
+                inner_end = record.INFO['END'] - abs(record.INFO['CIEND'][0])
                 outer_start = record.POS - abs(record.INFO['CIPOS'][0])
                 outer_end = record.INFO['END'] + record.INFO['CIEND'][1]
                 outer_start_end_component = observation.ObservationComponent()
                 outer_start_end_component.code = get_codeable_concept(
-                    ("http://hl7.org/fhir/uv/genomics-reporting" +
-                     "/CodeSystem/TbdCodes"),
-                    "outer-start-end", "Variant outer start and end"
+                    "http://loinc.org", "81301-4",
+                    "Variant outer start-end"
                 )
                 outer_start_end_component\
                     .valueRange = valRange.Range(
@@ -308,9 +307,8 @@ class _Fhir_Helper:
 
             inner_start_end_component = observation.ObservationComponent()
             inner_start_end_component.code = get_codeable_concept(
-                ("http://hl7.org/fhir/uv/ge" +
-                 "nomics-reporting/CodeSystem/TbdCodes"), "inner-start-end",
-                "Variant inner start and end"
+                "http://loinc.org", "81302-2",
+                "Variant inner start-end"
             )
             inner_start_end_component\
                 .valueRange = valRange.Range(
@@ -341,9 +339,8 @@ class _Fhir_Helper:
 
             exact_start_end_component = observation.ObservationComponent()
             exact_start_end_component.code = get_codeable_concept(
-                ("http://hl7.org/fhir/uv/genomics-reporting/Code" +
-                 "System/TbdCodes"), "exact-start-end",
-                "Variant exact start and end"
+                "http://loinc.org", "81254-5",
+                "Variant exact start-end"
             )
             exact_start_end_component.valueRange = valRange.Range(
                 {"low": {"value": int(record.POS)}})

--- a/vcf2fhir/test/expected_annotation.json
+++ b/vcf2fhir/test/expected_annotation.json
@@ -601,9 +601,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -673,7 +673,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "81259-4",
-                                "display": "Associated phenotype"
+                                "display": "predicted phenotype"
                             }
                         ]
                     },
@@ -1012,9 +1012,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1084,7 +1084,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "81259-4",
-                                "display": "Associated phenotype"
+                                "display": "predicted phenotype"
                             }
                         ]
                     },
@@ -1312,9 +1312,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1384,7 +1384,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "81259-4",
-                                "display": "Associated phenotype"
+                                "display": "predicted phenotype"
                             }
                         ]
                     },
@@ -1704,9 +1704,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1776,7 +1776,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "81259-4",
-                                "display": "Associated phenotype"
+                                "display": "predicted phenotype"
                             }
                         ]
                     },
@@ -2429,9 +2429,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -2501,7 +2501,7 @@
                             {
                                 "system": "http://loinc.org",
                                 "code": "81259-4",
-                                "display": "Associated phenotype"
+                                "display": "predicted phenotype"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_example1_with_patient.json
+++ b/vcf2fhir/test/expected_example1_with_patient.json
@@ -154,9 +154,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -373,9 +373,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -592,9 +592,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -811,9 +811,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1030,9 +1030,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1249,9 +1249,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1468,9 +1468,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_example1_wo_patient.json
+++ b/vcf2fhir/test/expected_example1_wo_patient.json
@@ -154,9 +154,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -373,9 +373,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -592,9 +592,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -811,9 +811,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1030,9 +1030,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1249,9 +1249,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1468,9 +1468,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_example3.json
+++ b/vcf2fhir/test/expected_example3.json
@@ -284,9 +284,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -503,9 +503,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -722,9 +722,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -941,9 +941,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -1268,9 +1268,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_example4.json
+++ b/vcf2fhir/test/expected_example4.json
@@ -2289,9 +2289,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -2508,9 +2508,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -2727,9 +2727,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -2946,9 +2946,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -3165,9 +3165,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },
@@ -3384,9 +3384,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "exact-start-end",
-                                "display": "Variant exact start and end"
+                                "system": "http://loinc.org",
+                                "code": "81254-5",
+                                "display": "Variant exact start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_fhir_germline_structural.json
+++ b/vcf2fhir/test/expected_fhir_germline_structural.json
@@ -182,9 +182,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -432,9 +432,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -682,9 +682,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -932,9 +932,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1198,9 +1198,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1464,9 +1464,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1730,9 +1730,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1996,9 +1996,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2246,9 +2246,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2496,9 +2496,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2762,9 +2762,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3024,9 +3024,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3254,9 +3254,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3504,9 +3504,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3766,9 +3766,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4032,9 +4032,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4282,9 +4282,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4544,9 +4544,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4794,9 +4794,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5044,9 +5044,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5294,9 +5294,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5540,9 +5540,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5786,9 +5786,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6032,9 +6032,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6278,9 +6278,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6524,9 +6524,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6770,9 +6770,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -7016,9 +7016,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -7262,9 +7262,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_fhir_mixed_structural.json
+++ b/vcf2fhir/test/expected_fhir_mixed_structural.json
@@ -142,9 +142,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -352,9 +352,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -562,9 +562,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -772,9 +772,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -982,9 +982,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1192,9 +1192,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1418,9 +1418,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1644,9 +1644,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1870,9 +1870,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2096,9 +2096,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2306,9 +2306,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2516,9 +2516,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2742,9 +2742,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2964,9 +2964,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3174,9 +3174,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3384,9 +3384,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3606,9 +3606,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3832,9 +3832,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4042,9 +4042,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4264,9 +4264,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4474,9 +4474,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4684,9 +4684,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4894,9 +4894,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5120,9 +5120,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5346,9 +5346,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5572,9 +5572,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5798,9 +5798,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6024,9 +6024,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6250,9 +6250,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6476,9 +6476,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6702,9 +6702,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },

--- a/vcf2fhir/test/expected_fhir_somatic_structural.json
+++ b/vcf2fhir/test/expected_fhir_somatic_structural.json
@@ -162,9 +162,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -392,9 +392,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -622,9 +622,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -852,9 +852,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1082,9 +1082,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1312,9 +1312,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1558,9 +1558,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -1804,9 +1804,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2050,9 +2050,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2296,9 +2296,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2526,9 +2526,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -2756,9 +2756,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3002,9 +3002,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3244,9 +3244,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3474,9 +3474,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3704,9 +3704,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -3946,9 +3946,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4192,9 +4192,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4422,9 +4422,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4664,9 +4664,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -4894,9 +4894,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5124,9 +5124,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5354,9 +5354,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5600,9 +5600,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -5846,9 +5846,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6092,9 +6092,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6338,9 +6338,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6584,9 +6584,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -6830,9 +6830,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -7076,9 +7076,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },
@@ -7322,9 +7322,9 @@
                     "code": {
                         "coding": [
                             {
-                                "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/TbdCodes",
-                                "code": "inner-start-end",
-                                "display": "Variant inner start and end"
+                                "system": "http://loinc.org",
+                                "code": "81302-2",
+                                "display": "Variant inner start-end"
                             }
                         ]
                     },


### PR DESCRIPTION
## Description

- `variant inner end` should be `INFO.END-|INFO.CIEND[0]|`
- component `exact-start-end` now has a LOINC code `81254-5`
- component inner-start-end now has a LOINC code `81302-2`
- component outer-start-end now has a LOINC code `81301-4`
- component LOINC `81259-4` now has a display of `predicted phenotype`


## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and the **PEP 8** formatting was validated using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
