### PR TITLE
Switch from PyVCF to PyVCF3 and update workflow to install dependencies from requirements.txt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install cython wheel
         run: pip install cython wheel
-      - name: Install vcf2fhir
-        run: pip install vcf2fhir
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
       - name: Run Unit tests
         run: python -m unittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Cython>=0.29.21
+fhirclient==3.2.0
+pysam
+pandas
+pytz>=2019.3
+PyVCF3>=1.0.3
+pyranges>=0.0.96

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     pysam
     pandas
     pytz>=2019.3
-    pyVCF>=0.6.8
+    PyVCF3>=1.0.3
     pyranges>=0.0.96
 tests_require =
     unittest

--- a/vcf2fhir/fhir_helper.py
+++ b/vcf2fhir/fhir_helper.py
@@ -82,7 +82,10 @@ class _Fhir_Helper:
         if(sample_data.GT is not None and
            len(sample_data.GT.split('|')) >= 2 and
            'PS' in sample_data._fields):
-            self.phased_rec_map.setdefault(sample_data.PS, []).append(record)
+            sample_data_ps = sample_data.PS
+            if isinstance(sample_data.PS, list):
+                sample_data_ps = sample_data_ps[0]
+            self.phased_rec_map.setdefault(sample_data_ps, []).append(record)
 
     def initalize_report(self):
         patient_reference = reference.FHIRReference(
@@ -266,12 +269,15 @@ class _Fhir_Helper:
                     "http://loinc.org", "82155-3",
                     "Genomic Structural Variant copy Number"
                 )
+                copy_number = record.samples[0]["CN"]
+                if isinstance(record.samples[0]["CN"], list):
+                    copy_number = copy_number[0]
                 copy_number_component\
                     .valueQuantity = quantity.Quantity(
                         {
                             "system": "http://unitsofmeasure.org",
                             "code": '1',
-                            "value": record.samples[0]["CN"]
+                            "value": copy_number
                         }
                     )
 


### PR DESCRIPTION
## Description

This pull request consists of two commits:

- First: Update code and setup file to switch from `PyVCF` to `PyVCF3` as the former is no longer maintained.
- Second: Update workflow to install dependencies from `requirements.txt` instead of installing the `vcf2fhir` package using `pip`.

## How Has This Been Tested?

The code has been tested by running all the tests using `python -m unittest` and the **PEP 8** formatting was validated using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
